### PR TITLE
Optimization restart and Fault-tolerance feature for the wolf optimizer and simulator

### DIFF
--- a/aero_optim/mesh/mesh.py
+++ b/aero_optim/mesh/mesh.py
@@ -197,7 +197,7 @@ class Mesh(ABC):
         # close gmsh
         gmsh.logger.stop()
         gmsh.finalize()
-        return os.path.join(mesh_dir, self.outfile + f".{self.mesh_format}")
+        return self.get_meshfile(mesh_dir)
 
     def reformat_2d(self, mesh: list[str]) -> list[str]:
         """
@@ -262,6 +262,12 @@ class Mesh(ABC):
                 line_data[2] = max(self.top_tags)
             mesh[id] = " " + f"{line_data[0]}" + " " + f"{line_data[1]}" + " " + f"{line_data[2]}"
         return mesh
+
+    def get_meshfile(self, mesh_dir: str) -> str:
+        """
+        **Returns** the path to the generated mesh.
+        """
+        return os.path.join(mesh_dir, self.outfile + f".{self.mesh_format}")
 
     @abstractmethod
     def process_config(self):

--- a/aero_optim/optim/optimizer.py
+++ b/aero_optim/optim/optimizer.py
@@ -215,10 +215,15 @@ class Optimizer(ABC):
     def mesh(self, ffdfile: str) -> str:
         """
         **Builds** mesh for a given candidate and returns its resulting file.
+
+        Note:
+            if a mesh file matching the pattern name already exists, it is not rebuilt.
         """
         mesh_dir = os.path.join(self.outdir, "MESH")
         check_dir(mesh_dir)
         gmsh_mesh = self.MeshClass(self.config, ffdfile)
+        if os.path.isfile(gmsh_mesh.get_meshfile(mesh_dir)):
+            return gmsh_mesh.get_meshfile(mesh_dir)
         gmsh_mesh.build_mesh()
         return gmsh_mesh.write_mesh(mesh_dir)
 

--- a/aero_optim/simulator/simulator.py
+++ b/aero_optim/simulator/simulator.py
@@ -226,7 +226,10 @@ class WolfSimulator(Simulator):
             elif returncode == 0:
                 logger.info(f"simulation {dict_id} finished")
                 finished_sim.append(id)
-                self.df_dict[dict_id["gid"]][dict_id["cid"]] = self.post_process(dict_id)
+                sim_out_dir = self.get_sim_outdir(dict_id["gid"], dict_id["cid"])
+                self.df_dict[dict_id["gid"]][dict_id["cid"]] = self.post_process(
+                    dict_id, sim_out_dir
+                )
                 break
             else:
                 raise Exception(f"ERROR -- simulation {dict_id} crashed")
@@ -234,17 +237,16 @@ class WolfSimulator(Simulator):
         self.sim_pro = [tup for id, tup in enumerate(self.sim_pro) if id not in finished_sim]
         return len(self.sim_pro)
 
-    def post_process(self, dict_id: dict) -> pd.DataFrame:
+    def post_process(self, dict_id: dict, sim_out_dir: str) -> pd.DataFrame:
         """
         **Post-processes** the results of a terminated simulation.</br>
         **Returns** the extracted results in a DataFrame.
         """
-        sim_out_dir = self.get_sim_outdir(dict_id["gid"], dict_id["cid"])
         qty_list: list[list[float]] = []
         head_list: list[str] = []
         # loop over the post-processing arguments to extract from the results
         for key, value in self.post_process_args.items():
-            # filter removes possible blank lines avoiding index out of range errors at L186
+            # filter removes possible blank lines avoiding index out of range errors
             file = list(filter(None, open(os.path.join(sim_out_dir, key), "r").read().splitlines()))
             headers = file[0][2:].split()  # ignore "# " before first item in headers
             for qty in value:

--- a/tests/extras/test_simulator_config.json
+++ b/tests/extras/test_simulator_config.json
@@ -1,7 +1,7 @@
 {
     "study": {
         "study_type": "base",
-        "outdir": "output"
+        "outdir": "output_simulator"
     },
     "simulator": {
         "ref_input": "tests/extras/empty_file.wolf",

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -23,7 +23,7 @@ def wolf() -> WolfSimulator:
 
 def test_execute_sim(wolf: WolfSimulator):
     wolf.execute_sim(meshfile=mesh_file_path)
-    assert wolf.sim_pro[0][0] == {'cid': 0, 'gid': 0}
+    assert wolf.sim_pro[0][0] == {'cid': 0, 'gid': 0, "meshfile": mesh_file_path, "restart": 0}
     assert wolf.sim_pro[0][-1].args == ["python3", executable_path, "-in", mesh_file]
     assert wolf.df_dict[0] == {}
 


### PR DESCRIPTION
This PR introduces several changes at the simulator, mesh and optimizer levels to make the framework restartable and fault-tolerant:
- a `restart` attribute is added to `WolfSimulator` so that a failed simulation can be restarted `restart` times before raising an exception.
- the `execute_sim` method of `WolfSimulator` is modified in order to try to load existing results before performing the simulation.
- the `mesh` method of the `Optimizer` class is modified so that the mesh is only built when is does not already exists.

Note: these two last features make it possible to restart an optimization from an existing one, to push it further or to reuse pre-existing results.
