### PR TITLE
Fix RAE2822 input file

### DIFF
--- a/examples/RAE2822/rae2822_adap/rae2822_adap.wolf
+++ b/examples/RAE2822/rae2822_adap/rae2822_adap.wolf
@@ -58,9 +58,7 @@ SGSNumberOfSubIterations
 LinearSystemResidual
 0.02
 
-DefectCorrection
-DeCNumberOfIterations
-1
+LinearSystemLineSearch
 
 Cfl
 0.1

--- a/examples/RAE2822/rae2822_base/rae2822_base.wolf
+++ b/examples/RAE2822/rae2822_base/rae2822_base.wolf
@@ -62,9 +62,7 @@ SGSNumberOfSubIterations
 LinearSystemResidual
 0.02
 
-DefectCorrection
-DeCNumberOfIterations
-1
+LinearSystemLineSearch
 
 Cfl
 0.1


### PR DESCRIPTION
This PR improves the RAE2822 wolf input file by removing the unnecessary `DefectCorrection` option and adding  the `LinearSystemLineSearch` option susceptible to improve the stability of the solver for this case.