### PR TITLE
Minor features improvements

### DIFF
--- a/aero_optim/ffd/ffd.py
+++ b/aero_optim/ffd/ffd.py
@@ -83,7 +83,8 @@ class FFD_2D(Deform):
     with (P00, P30, P01, P31) fixed if pad = (1, 1).
     """
     def __init__(
-            self, dat_file: str, ncontrol: int, pad: tuple[int, int] = (1, 1), header: int = 2
+            self, dat_file: str, ncontrol: int,
+            pad: tuple[int, int] = (1, 1), header: int = 2, **kwargs
     ):
         """
         Instantiates the FFD_2D object.

--- a/aero_optim/utils.py
+++ b/aero_optim/utils.py
@@ -263,19 +263,29 @@ def ln_filelist(in_files: list[str], out_files: list[str]):
             os.rename("tmplink", out_f)
 
 
-def submit_popen_process(name: str, exec_cmd: list[str]) -> tuple[str, subprocess.Popen[str]]:
+def submit_popen_process(
+        name: str, exec_cmd: list[str], dir: str = ""
+) -> tuple[str, subprocess.Popen[str]]:
     """
     Wrapper around Popen. It submits exec_cmd and returns the corresponding tuple (name, process).
     """
     with open(f"{name}.out", "wb") as out:
         with open(f"{name}.err", "wb") as err:
             print(f"INFO -- execute {name}")
+            # move to dir if specified
+            if dir:
+                cwd = os.getcwd()
+                os.chdir(dir)
+            # submit subprocess
             proc = subprocess.Popen(exec_cmd,
                                     env=os.environ,
                                     stdin=subprocess.DEVNULL,
                                     stdout=out,
                                     stderr=err,
                                     universal_newlines=True)
+            # move back to the initial working dir
+            if dir:
+                os.chdir(cwd)
     return (name, proc)
 
 


### PR DESCRIPTION
This PR implements the following improvements:
1. a `**kwargs` attribute is added to the `FFD_2D` initializer so that it does not fail if unexpected ffd attributes are present in the config. This makes it possible to perform standard FFD even if  POD related attributes are defined in the `"ffd"` entry of the config file.
2. a `dir` attribute is added to the `subprocess.Popen` wrapper so that it can move to `dir`, submit the process and move back to the original working directory. By default `dir=""` and the process is submitted in the current working directory. 